### PR TITLE
feat: added banner and update subscription check to make maintained actions free for public repos

### DIFF
--- a/.github/workflows/actions_release.yml
+++ b/.github/workflows/actions_release.yml
@@ -10,6 +10,10 @@ on:
         description: "Specify the npm/yarn script to run"
         required: false
         default: "yarn build"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
 permissions:
   contents: read
@@ -24,3 +28,4 @@ jobs:
     with:
       tag: "${{ github.event.inputs.tag }}"
       script: "${{ github.event.inputs.script }}"
+      node_version: "${{ github.event.inputs.node_version }}"

--- a/.github/workflows/audit_package.yml
+++ b/.github/workflows/audit_package.yml
@@ -15,8 +15,12 @@ on:
         description: "Specify the npm/yarn script to run"
         required: false
         default: "yarn build"
-      
-  
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
+
+
   schedule:
     - cron: "0 0 * * 1"
 
@@ -27,6 +31,7 @@ jobs:
       base_branch: ${{ github.event.inputs.base_branch || 'main' }}
       package_manager: "yarn"
       script: "${{ github.event.inputs.script || 'yarn build' }}"
+      node_version: "${{ inputs.node_version || '24' }}"
 
 permissions:
   contents: write

--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -19,6 +19,10 @@ on:
         description: "Run mode: cherry-pick or verify"
         required: false
         default: "cherry-pick"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
   pull_request:
     types: [opened, synchronize, labeled]
@@ -40,3 +44,4 @@ jobs:
       package_manager: "yarn"
       script: ${{ inputs.script || 'yarn build' }}
       mode: ${{ github.event_name == 'pull_request' && 'verify' || inputs.mode }}
+      node_version: "${{ inputs.node_version || '24' }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
-          node-version: 16
+          node-version: 24
           cache: yarn
         if: env.RUNNING
       - name: Install Package dependencies
@@ -94,7 +94,7 @@ jobs:
 
       - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
-          node-version: 16
+          node-version: 24
           cache: yarn
         if: env.RUNNING
       - name: Install Package dependencies

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 StepSecurity
+Copyright (c) 2026 StepSecurity
 Copyright (c) 2019 Technote
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
 # Assign Author
 
 [![CI Status](https://github.com/step-security/assign-author/workflows/CI/badge.svg)](https://github.com/step-security/assign-author/actions)

--- a/action.yml
+++ b/action.yml
@@ -13,5 +13,5 @@ branding:
   color: 'orange'
 
 runs:
-  using: node20
+  using: node24
   main: dist/main.js

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,8 +1,8 @@
 'use strict';
 
+var fs$2 = require('fs');
 var path$1 = require('path');
 var require$$0$1 = require('os');
-var fs$2 = require('fs');
 var http$3 = require('http');
 var https$3 = require('https');
 require('net');
@@ -18,6 +18,25 @@ require('child_process');
 var require$$8 = require('crypto');
 var http2 = require('http2');
 var require$$1$3 = require('tty');
+
+function _interopNamespaceDefault(e) {
+	var n = Object.create(null);
+	if (e) {
+		Object.keys(e).forEach(function (k) {
+			if (k !== 'default') {
+				var d = Object.getOwnPropertyDescriptor(e, k);
+				Object.defineProperty(n, k, d.get ? d : {
+					enumerable: true,
+					get: function () { return e[k]; }
+				});
+			}
+		});
+	}
+	n.default = e;
+	return Object.freeze(n);
+}
+
+var fs__namespace = /*#__PURE__*/_interopNamespaceDefault(fs$2);
 
 var commonjsGlobal = typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
 
@@ -108970,18 +108989,39 @@ const addAssignees = async (assignees, octokit, logger, context) => {
 const execute = async (logger, octokit, context) => addAssignees(getAssignees(context), octokit, logger, context);
 
 async function validateSubscription() {
-    const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`;
+    const eventPath = process.env.GITHUB_EVENT_PATH;
+    let repoPrivate;
+    if (eventPath && fs__namespace.existsSync(eventPath)) {
+        const eventData = JSON.parse(fs__namespace.readFileSync(eventPath, 'utf8'));
+        repoPrivate = eventData?.repository?.private;
+    }
+    const upstream = 'technote-space/assign-author';
+    const action = process.env.GITHUB_ACTION_REPOSITORY;
+    const docsUrl = 'https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions';
+    coreExports.info('');
+    coreExports.info('\u001b[1;36mStepSecurity Maintained Action\u001b[0m');
+    coreExports.info(`Secure drop-in replacement for ${upstream}`);
+    if (repoPrivate === false) {
+        coreExports.info('\u001b[32m\u2713 Free for public repositories\u001b[0m');
+    }
+    coreExports.info(`\u001b[36mLearn more:\u001b[0m ${docsUrl}`);
+    coreExports.info('');
+    if (repoPrivate === false)
+        return;
+    const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
+    const body = { action: action || '' };
+    if (serverUrl !== 'https://github.com')
+        body['ghes_server'] = serverUrl;
     try {
-        await axios$1.get(API_URL, { timeout: 3000 });
+        await axios$1.post(`https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`, body, { timeout: 3000 });
     }
     catch (error) {
         if (isAxiosError(error) && error.response?.status === 403) {
-            coreExports.error('Subscription is not valid. Reach out to support@stepsecurity.io');
+            coreExports.error('\u001b[1;31mThis action requires a StepSecurity subscription for private repositories.\u001b[0m');
+            coreExports.error(`\u001b[31mLearn how to enable a subscription: ${docsUrl}\u001b[0m`);
             process.exit(1);
         }
-        else {
-            coreExports.info('Timeout or API not reachable. Continuing to next step.');
-        }
+        coreExports.info('Timeout or API not reachable. Continuing to next step.');
     }
 }
 const run = async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import { resolve } from 'path';
 import { setFailed } from '@actions/core';
 import * as core from '@actions/core';
@@ -10,19 +11,50 @@ import { TARGET_EVENTS } from './constant';
 import { execute } from './process';
 
 async function validateSubscription(): Promise<void> {
-  const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  let repoPrivate: boolean | undefined;
 
+  if (eventPath && fs.existsSync(eventPath)) {
+    const eventData = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+    repoPrivate = eventData?.repository?.private;
+  }
+
+  const upstream = 'technote-space/assign-author';
+  const action = process.env.GITHUB_ACTION_REPOSITORY;
+  const docsUrl =
+    'https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions';
+
+  core.info('');
+  core.info('\u001b[1;36mStepSecurity Maintained Action\u001b[0m');
+  core.info(`Secure drop-in replacement for ${upstream}`);
+  if (repoPrivate === false) {
+    core.info('\u001b[32m\u2713 Free for public repositories\u001b[0m');
+  }
+  core.info(`\u001b[36mLearn more:\u001b[0m ${docsUrl}`);
+  core.info('');
+
+  if (repoPrivate === false) return;
+
+  const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
+  const body: Record<string, string> = {action: action || ''};
+  if (serverUrl !== 'https://github.com') body['ghes_server'] = serverUrl;
   try {
-    await axios.get(API_URL, {timeout: 3000});
+    await axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      {timeout: 3000}
+    );
   } catch (error) {
     if (isAxiosError(error) && error.response?.status === 403) {
       core.error(
-        'Subscription is not valid. Reach out to support@stepsecurity.io'
+        '\u001b[1;31mThis action requires a StepSecurity subscription for private repositories.\u001b[0m'
+      );
+      core.error(
+        `\u001b[31mLearn how to enable a subscription: ${docsUrl}\u001b[0m`
       );
       process.exit(1);
-    } else {
-      core.info('Timeout or API not reachable. Continuing to next step.');
     }
+    core.info('Timeout or API not reachable. Continuing to next step.');
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,10 @@
   "extends": "@sindresorhus/tsconfig",
   "compilerOptions": {
     "outDir": "dist",
-    "target": "ES2021",
+    "target": "ES2022",
     "module": "ES2020",
     "lib": [
-      "ES2021"
+      "ES2022"
     ],
     "moduleResolution": "node",
     "noPropertyAccessFromIndexSignature": false,


### PR DESCRIPTION
## Summary

- Added StepSecurity Maintained Action banner to README.md
- Updated subscription validation: public repositories are now free (no API check)
- Upgraded Node.js runtime to node24 (if applicable)
- Updated workflow files with configurable node_version input (if applicable)

## Changes by type
- **TypeScript/JS actions**: replaced `validateSubscription()` body, updated action.yml to node24, updated 3 workflow files, rebuilt dist/
- **Docker actions**: replaced entrypoint.sh subscription block, ensured jq is installed in Dockerfile
- **Composite actions**: added Subscription check step to action.yml

## Verification
- [ ] Subscription check skips for public repos
- [ ] Subscription check fires for private repos
- [ ] README banner is present at the top
- [ ] Build passes (TS/JS actions)

Auto-generated by StepSecurity update-propagator. Task ID: 20260409T074908Z